### PR TITLE
Add inflection sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.json
 !tag_bank_term.json
 !tag_bank_ipa.json
+!tag_order.json
 !languages.json
 !package.json
 !data/test/kaikki/*.json

--- a/3-tidy-up.js
+++ b/3-tidy-up.js
@@ -9,6 +9,8 @@ const {
     tidy_folder: writeFolder
 } = process.env;
 
+const { sortTags, similarSort } = require('./util/sort-tags');
+
 function isInflectionGloss(glosses) {
     if (targetIso === 'en') {
         return /.*inflection of.*/.test(JSON.stringify(glosses));
@@ -130,16 +132,16 @@ function handleLine(line, lemmaDict, formDict, formStuff, automatedForms) {
             forms.forEach((formData) => {
                 const { form, tags } = formData;
 
-                if (form && tags && !tags.some(value => blacklistedTags.includes(value))) {
+                if (form && tags && !tags.some(value => blacklistedTags.includes(value)) && form !== '-') {
                     automatedForms[form] ??= {};
-                    automatedForms[form][word] = {};
+                    automatedForms[form][word] ??= {};
                     automatedForms[form][word][pos] ??= new Set();
 
                     const tagsSet = new Set(automatedForms[form][word][pos]);
 
-                    tagsSet.add(tags.join(' '));
+                    tagsSet.add(sortTags(targetIso, tags).join(' '));
 
-                    automatedForms[form][word][pos] = Array.from(tagsSet);
+                    automatedForms[form][word][pos] = similarSort(Array.from(tagsSet));
                 }
             });
         }

--- a/4-make-yomitan.js
+++ b/4-make-yomitan.js
@@ -6,6 +6,8 @@ const {source_iso, target_iso, DEBUG_WORD, DICT_NAME} = process.env;
 
 const currentDate = date.format(now, 'YYYY.MM.DD');
 
+const { sortTags } = require('./util/sort-tags');
+
 consoleOverwrite(`4-make-yomitan.js: reading lemmas...`);
 const lemmaDict = JSON.parse(readFileSync(`data/tidy/${source_iso}-${target_iso}-lemmas.json`));
 consoleOverwrite(`4-make-yomitan.js: reading forms...`);
@@ -292,19 +294,19 @@ for (const [form, allInfo] of Object.entries(formDict)) {
             uniqueHypotheses = [];
 
             for (const hypothesis of inflectionHypotheses) {
-                const hypothesisStrings = uniqueHypotheses.map((hypothesis) => hypothesis.sort().join(' '));
-                const hypothesisString = hypothesis.sort().join(' ');
+                const hypothesisStrings = uniqueHypotheses.map((hypothesis) => sortTags(target_iso, hypothesis).join(' '));
+                const hypothesisString = sortTags(target_iso, hypothesis).join(' ');
                 if (!hypothesisStrings.includes(hypothesisString)) {
                     uniqueHypotheses.push(hypothesis);
                 }
             }
 
-            deinflectionDefinitions = uniqueHypotheses.map((hypothesis) => [
+            const deinflectionDefinitions = uniqueHypotheses.map((hypothesis) => [
                 normalizeOrthography(lemma),
                 hypothesis
             ]);
 
-            if(deinflectionDefinitions.length){
+            if(deinflectionDefinitions.length > 0){
                 ymt.form.push([
                     normalizeOrthography(form),
                     '',

--- a/data/language/tag_order.json
+++ b/data/language/tag_order.json
@@ -1,0 +1,95 @@
+{
+    "formality": [
+        "informal",
+        "formal"
+    ],
+    "cases": [
+        "nominative",
+        "genitive",
+        "dative",
+        "accusative",
+        "vocative",
+        "locative",
+        "instrumental"
+    ],
+    "persons": [
+        "first-person",
+        "second-person",
+        "third-person",
+        "first/third-person",
+        "first-person-semantically",
+        "second-person-semantically",
+        "third-person-semantically"
+    ],
+    "numbers": [
+        "singular",
+        "plural",
+        "plural-only"
+    ],
+    "definitiveness": [
+        "definite",
+        "indefinite"
+    ],
+    "genders": [
+        "masculine",
+        "feminine",
+        "neuter",
+        "common-gender"
+    ],
+    "animacy": [
+        "inanimate",
+        "animate"
+    ],
+    "comparativeForms": [
+        "comparative",
+        "positive",
+        "superlative"
+    ],
+    "tenses": [
+        "present",
+        "past",
+        "future",
+        "future-i",
+        "future-ii",
+        "perfect",
+        "pluperfect",
+        "aorist",
+        "imperfect",
+        "conditional",
+        "conditional-i",
+        "conditional-ii"
+    ],
+    "verbForms": [
+        "imperative",
+        "gerund",
+        "imperfective",
+        "perfective",
+        "active",
+        "passive",
+        "participle",
+        "subjunctive",
+        "indicative"
+    ],
+    "modifiers": [
+        "adjective",
+        "noun-from-verb",
+        "infinitive",
+        "adverbial",
+        "emphatic",
+        "relational",
+        "diminutive",
+        "poetic",
+        "regional",
+        "rare",
+        "augmentative",
+        "archaic",
+        "with-genitive",
+        "object-first-person",
+        "object-second-person",
+        "object-third-person",
+        "object-singular",
+        "object-plural",
+        "negative",
+        "combined-form"
+    ]
+}

--- a/util/sort-tags.js
+++ b/util/sort-tags.js
@@ -1,0 +1,59 @@
+const { readFileSync } = require('fs');
+
+const tagOrder = JSON.parse(readFileSync('data/language/tag_order.json'));
+
+const tagOrderAll = [];
+
+for (const [, tags] of Object.entries(tagOrder)) {
+    tagOrderAll.push(...tags);
+}
+
+// sorts tags to follow `tag_order.json`
+// tags not in tag_order are simply added to end of array
+
+function sortTags(targetIso, tags) {
+    if (targetIso !== 'en') return tags;
+
+    return tags.sort((a, b) => {
+        const indexA = tagOrderAll.indexOf(a);
+        const indexB = tagOrderAll.indexOf(b);
+
+        // Check if the tags are in tagOrder
+        const isInOrderA = indexA !== -1;
+        const isInOrderB = indexB !== -1;
+
+        // Handle cases where both tags are in tagOrder or both are not
+        if ((isInOrderA && isInOrderB) || (!isInOrderA && !isInOrderB)) {
+            return indexA - indexB;
+        }
+
+        // Place the tag that is in tagOrder before the one that is not
+        return isInOrderA ? -1 : 1;
+    });
+}
+
+// sorts inflection entries to be nearby similar inflections
+
+function similarSort(tags) {
+    return tags.sort((a, b) => {
+        const aWords = a.split(' ');
+        const bWords = b.split(' ');
+
+        // Check if the second word exists before comparing
+        const mainComparison = (aWords[1] || '').localeCompare(bWords[1] || '');
+
+        if (mainComparison !== 0) {
+            return mainComparison;
+        }
+
+        for (let i = 0; i < Math.min(aWords.length, bWords.length); i++) {
+            if (aWords[i] !== bWords[i]) {
+                return aWords[i].localeCompare(bWords[i]);
+            }
+        }
+
+        return aWords.length - bWords.length;
+    });
+}
+
+module.exports = { sortTags, similarSort };


### PR DESCRIPTION
Inflection order can be a complete illegible mess. This sorts inflections to be much more clean. Only working for English Wiktionary currently.

Here's an example of before the change:

```js
multiplique [
  'first-person present singular subjunctive',
  'present singular subjunctive third-person',
  'formal imperative second-person-semantically singular third-person',
  'imperative singular third-person',
  'formal imperative negative second-person-semantically singular third-person',
  'imperative negative singular third-person'
]
```

Here's after:

```js
multiplique [
  'first-person singular present subjunctive',
  'third-person singular imperative',
  'third-person singular imperative negative',
  'third-person singular present subjunctive',
  'formal third-person second-person-semantically singular imperative',
  'formal third-person second-person-semantically singular imperative negative'
]
```