### PR TITLE
remove junk text from some headwords

### DIFF
--- a/3-tidy-up.js
+++ b/3-tidy-up.js
@@ -285,6 +285,10 @@ function getCanonicalForm({word, forms}) {
     );
     if (canonicalForm) {
         word = canonicalForm.form;
+
+        if (word.includes('{{#ifexist:Wiktionary')) {
+            word = word.replace(/ {{#if:.+/, '');
+        }
     }
     return word;
 }


### PR DESCRIPTION
Words like "in" for German, "а" for Russian, and "me" for French all had this junk text appended to it:

`{{#if:{{{tr|}}}|{{#ifexist:Wiktionary:{{{langname}}} transliteration|`

This is most likely due to a wiktextract bug, since I can't find that text in the actual Wiktionary page for those entries.

With the fix added to `getCanonicalForm`, the entries are now correctly added to their dictionaries.