### PR TITLE
Added Old English; Removed Diacritics in SGA, GRC and ANG

### DIFF
--- a/4-make-yomitan.js
+++ b/4-make-yomitan.js
@@ -508,6 +508,9 @@ function normalizeOrthography(term) {
             
             return term.replace(diacriticsRegex, '')
         case 'la':
+        case 'ang':
+        case 'sga':
+        case 'grc':
             return term.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
         case 'ru':
             return term.replace(/́/g, '');

--- a/languages.json
+++ b/languages.json
@@ -1,5 +1,6 @@
 [
     {"iso": "afb", "language": "Gulf Arabic",    "flag": "🇦🇪"},
+    {"iso": "ang", "language": "Old English",    "flag": "🗡️"},
     {"iso": "ar",  "language": "Arabic",         "flag": "🇪🇬"},
     {"iso": "de",  "language": "German",         "flag": "🇩🇪"},
     {"iso": "el",  "language": "Greek",          "flag": "🇬🇷"},


### PR DESCRIPTION
Without removing these diacritics as a pre-processing step, words are hard to find when using Yomitan.