### PR TITLE
allow wildcard format for language names when running auto.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: npm install
 
       - name: Run auto.sh script
-        run: ./auto.sh any any ST
+        run: ./auto.sh ? ?
       
       - name: Generate list of .zip files
         id: generate_file_list

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Converts wiktionary data from https://kaikki.org/ to yomitan-compatible dictiona
 
 ## Contributing
 
+Instead of a language name, you can also write `?` to run for all languages.
+- `./auto.sh ? English` will run for any language to English.
+- `./auto.sh German ?` will run for German to any language.
+
 The `auto.sh` script can also be run with flags:
 
 - k: keep files (by default, the script deletes the downloaded files after running),
@@ -23,8 +27,6 @@ The `auto.sh` script can also be run with flags:
 - t: force_tidy (run tidy script again, even if its output already exists. useful when the tidy script is updated),
 - y: force_ymt (run yomitan script again, even if its output already exists. useful when the yomitan script is updated),
 - F: force = force_tidy + force_ymt,
-- S: run for all source languages (`./auto.sh German English S` is like `./auto.sh * English`),
-- T: run for all target languages (`./auto.sh German English T` is like `./auto.sh German *`).
 
 Most often, you will want to run `./auto.sh German English kty` to recreate the dictionaries, then load them in yomitan and test them.
 

--- a/auto.sh
+++ b/auto.sh
@@ -13,8 +13,6 @@ if [ -z "$1" ] || [ -z "$2" ]; then
 fi
 
 # Parse flags
-source_all=false
-target_all=false
 redownload=false
 force_tidy=false
 force_ymt=false
@@ -26,8 +24,6 @@ for flag in "${flags[@]}"; do
   case "$3" in 
     *"$flag"*) 
       case "$flag" in
-        'S') source_all=true ;;
-        'T') target_all=true ;;
         'd') redownload=true ;;
         't') force_tidy=true ;;
         'y') force_ymt=true ;;
@@ -47,8 +43,6 @@ if [ "$force_tidy" = true ]; then
   force_ymt=true
 fi
 
-echo "[S] source_all: $source_all"
-echo "[T] target_all: $target_all"
 echo "[d] redownload: $redownload"
 echo "[F] force: $force"
 echo "[t] force_tidy: $force_tidy"
@@ -61,8 +55,8 @@ npm i
 # Step 2: Run create-folder.js
 node 1-create-folders.js
 
-source_language="$1"
-target_language="$2"
+language_source="$1"
+language_target="$2"
 
 declare -a languages="($(
   jq -r '.[] | @json | @sh' languages.json
@@ -72,11 +66,11 @@ for target_lang in "${languages[@]}"; do
   target_iso=$(echo "${target_lang}" | jq -r '.iso')
   target_language_name=$(echo "${target_lang}" | jq -r '.language')
     
-  if [ "$target_language_name" != "$target_language" ] && [ "$target_all" = false ]; then
+  if [ "$target_language_name" != "$language_target" ] && [ "$language_target" != "?" ]; then
       continue
   fi
 
-    target_languages="es de en fr ru zh"
+    target_languages="de en es fr ru zh"
     if [[ ! "$target_languages" == *"$target_iso"* ]]; then
       echo "Unsupported target language: $target_iso"
       continue
@@ -91,7 +85,7 @@ for target_lang in "${languages[@]}"; do
     language=$(echo "${source_lang}" | jq -r '.language')
     flag=$(echo "${source_lang}" | jq -r '.flag')
     
-    if [ "$language" != "$source_language" ] && [ "$source_all" = false ]; then
+    if [ "$language" != "$language_source" ] && [ "$language_source" != "?" ]; then
       continue
     fi
 


### PR DESCRIPTION
Instead of the S and T flags, I think it's simpler to use a `?` for all languages. (`*` has some issues with bash behavior)