### PR TITLE
Update french tag_bank_term.json

### DIFF
--- a/data/language/target-language-tags/fr/tag_bank_term.json
+++ b/data/language/target-language-tags/fr/tag_bank_term.json
@@ -3,7 +3,7 @@
      "tort",
      "",
      0,
-     "Utilisé à tort",
+     ["Utilisé à tort", "Par erreur ?"],
      0
    ],
    [
@@ -14,7 +14,7 @@
      0
    ],
    [
-     "usage critiqué",
+     "critiqué",
      "",
      0,
      "Usage critiqué",
@@ -28,10 +28,10 @@
      0
    ],
    [
-     "abus de langage",
+     "par abus",
      "",
      0,
-     "Abusivement",
+     ["Par abus", "Abusivement", "Abus de langage", "Usage abusif"],
      0
    ],
    [
@@ -42,38 +42,10 @@
      0
    ],
    [
-     "abus de langage",
-     "",
-     0,
-     "Abus de langage",
-     0
-   ],
-   [
-     "abus de langage",
-     "",
-     0,
-     "Par abus",
-     0
-   ],
-   [
-     "abus de langage",
-     "",
-     0,
-     "Usage abusif",
-     0
-   ],
-   [
      "non standard",
      "",
      0,
      "Verbe non standard",
-     0
-   ],
-   [
-     "tort",
-     "",
-     0,
-     "Par erreur ?",
      0
    ]
  ]

--- a/data/language/target-language-tags/fr/tag_bank_term.json
+++ b/data/language/target-language-tags/fr/tag_bank_term.json
@@ -5,5 +5,173 @@
      0,
      "Utilisé à tort",
      0
+   ],
+   [
+     "verlan",
+     "",
+     0,
+     "Verlan",
+     0
+   ],
+   [
+     "désuet",
+     "",
+     0,
+     "Archaïque",
+     0
+   ],
+   [
+     "usage critiqué",
+     "",
+     0,
+     "Usage critiqué",
+     0
+   ],
+   [
+     "par confusion",
+     "",
+     0,
+     "Par confusion",
+     0
+   ],
+   [
+     "inusité",
+     "",
+     0,
+     "Inusité",
+     0
+   ],
+   [
+     "désuet",
+     "",
+     0,
+     "désuet",
+     0
+   ],
+   [
+     "désuet en France",
+     "",
+     0,
+     "Vieilli sauf au Canada",
+     0
+   ],
+   [
+     "désuet en France",
+     "",
+     0,
+     "Désuet sauf au Canada",
+     0
+   ],
+   [
+     "abus de langage",
+     "",
+     0,
+     "Abusivement",
+     0
+   ],
+   [
+     "impropre",
+     "",
+     0,
+     "Impropre",
+     0
+   ],
+   [
+     "abus de langage",
+     "",
+     0,
+     "Abus de langage",
+     0
+   ],
+   [
+     "faux-ami",
+     "",
+     0,
+     "Faux-ami",
+     0
+   ],
+   [
+     "désuet en France",
+     "",
+     0,
+     "Désuet sauf en Acadie",
+     0
+   ],
+   [
+     "inusité",
+     "",
+     0,
+     "désormais inusité",
+     0
+   ],
+   [
+     "inusité",
+     "",
+     0,
+     "inusité",
+     0
+   ],
+   [
+     "abus de langage",
+     "",
+     0,
+     "Par abus",
+     0
+   ],
+   [
+     "inusité",
+     "",
+     0,
+     "Inutilisé",
+     0
+   ],
+   [
+     "abus de langage",
+     "",
+     0,
+     "Usage abusif",
+     0
+   ],
+   [
+     "inusité",
+     "",
+     0,
+     "Sens inusité donné dans Besch. 1845",
+     0
+   ],
+   [
+     "inusité",
+     "",
+     0,
+     "Mot inusité",
+     0
+   ],
+   [
+     "non standard",
+     "",
+     0,
+     "Verbe non standard",
+     0
+   ],
+   [
+     "désuet en France",
+     "",
+     0,
+     "En usage jusqu'au XVIIᵉ siècle",
+     0
+   ],
+   [
+     "tort",
+     "",
+     0,
+     "Par erreur ?",
+     0
+   ],
+   [
+     "inusité",
+     "",
+     0,
+     "Inutilisé",
+     0
    ]
  ]

--- a/data/language/target-language-tags/fr/tag_bank_term.json
+++ b/data/language/target-language-tags/fr/tag_bank_term.json
@@ -14,13 +14,6 @@
      0
    ],
    [
-     "désuet",
-     "",
-     0,
-     "Archaïque",
-     0
-   ],
-   [
      "usage critiqué",
      "",
      0,
@@ -32,34 +25,6 @@
      "",
      0,
      "Par confusion",
-     0
-   ],
-   [
-     "inusité",
-     "",
-     0,
-     "Inusité",
-     0
-   ],
-   [
-     "désuet",
-     "",
-     0,
-     "désuet",
-     0
-   ],
-   [
-     "désuet en France",
-     "",
-     0,
-     "Vieilli sauf au Canada",
-     0
-   ],
-   [
-     "désuet en France",
-     "",
-     0,
-     "Désuet sauf au Canada",
      0
    ],
    [
@@ -84,45 +49,10 @@
      0
    ],
    [
-     "faux-ami",
-     "",
-     0,
-     "Faux-ami",
-     0
-   ],
-   [
-     "désuet en France",
-     "",
-     0,
-     "Désuet sauf en Acadie",
-     0
-   ],
-   [
-     "inusité",
-     "",
-     0,
-     "désormais inusité",
-     0
-   ],
-   [
-     "inusité",
-     "",
-     0,
-     "inusité",
-     0
-   ],
-   [
      "abus de langage",
      "",
      0,
      "Par abus",
-     0
-   ],
-   [
-     "inusité",
-     "",
-     0,
-     "Inutilisé",
      0
    ],
    [
@@ -133,20 +63,6 @@
      0
    ],
    [
-     "inusité",
-     "",
-     0,
-     "Sens inusité donné dans Besch. 1845",
-     0
-   ],
-   [
-     "inusité",
-     "",
-     0,
-     "Mot inusité",
-     0
-   ],
-   [
      "non standard",
      "",
      0,
@@ -154,24 +70,10 @@
      0
    ],
    [
-     "désuet en France",
-     "",
-     0,
-     "En usage jusqu'au XVIIᵉ siècle",
-     0
-   ],
-   [
      "tort",
      "",
      0,
      "Par erreur ?",
-     0
-   ],
-   [
-     "inusité",
-     "",
-     0,
-     "Inutilisé",
      0
    ]
  ]


### PR DESCRIPTION
So I checked the skippedTermTags file and I retained, I hope, the most important tags.

**verlan**: somehow the reverse of a word, like meuf, ouf and rebeu are verlan for femme, fou and arabe.

**abus de langage**: commonly(but wrongly)

**usage critiqué**: criticized usage, could be under commonly

**impropre**: improper

**non standard**: ...

**par confusion**: mistakenly

**tort**: wrongly


you can change them if you want.