### PR TITLE
[tl] Remove hyphen and apostrophe

### DIFF
--- a/4-make-yomitan.js
+++ b/4-make-yomitan.js
@@ -514,8 +514,9 @@ function normalizeOrthography(term) {
         case 'sga':
         case 'grc':
         case 'ro':
-        case 'tl':
             return term.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+        case 'tl':
+            return term.normalize('NFD').replace(/[\u0300-\u036f\-']/g, '');
         case 'sh':
             return term.normalize('NFD').replace(/[aeiourAEIOUR][\u0300-\u036f]/g, (match) => match[0]);
         case 'uk':


### PR DESCRIPTION
Hyphens and apostrophes are optional in Tagalog, so removing them may allow looking up more terms.
#112 