### PR TITLE
handle missing russian inflections

### DIFF
--- a/3-tidy-up.js
+++ b/3-tidy-up.js
@@ -509,7 +509,7 @@ function processEnglishInflectionGlosses(glosses, word, pos) {
     /**  @type {Set<string>} */
     const inflections = new Set();
     for (const piece of glossPieces) {
-        const lemmaMatch = piece.match(/of ([^\s]+)\s*$/);
+        const lemmaMatch = piece.match(/of ([^\s]+)\s*(\(.+?\))?$/);
         if (lemmaMatch) {
             lemmas.add(lemmaMatch[1].replace(/:/g, '').trim());
         }
@@ -531,6 +531,7 @@ function processEnglishInflectionGlosses(glosses, word, pos) {
             .replace(new RegExp(`${escapedLemma}`), '')
             .replace(new RegExp(`\\s+`), ' ')
             .replace(/:/g, '')
+            .replace(/\s*\(.+?\)$/, '')
             .trim();
 
         inflections.add(inflection); 
@@ -686,7 +687,7 @@ function handleAutomatedForms() {
         automatedForms.delete(lemma);
     }
 
-    console.log(`There were ${missingForms} missing forms that have now been automatically populated.`);
+    console.log(`\nThere were ${missingForms} missing forms that have now been automatically populated.`);
 }
 
 lr.on('end', () => {

--- a/data/test/dict/ru/en/term_bank_2.json
+++ b/data/test/dict/ru/en/term_bank_2.json
@@ -1,5 +1,45 @@
 [
   [
+    "возник",
+    "возни́к",
+    "non-lemma",
+    "",
+    0,
+    [
+      [
+        "возни́кнуть",
+        [
+          "singular",
+          "masculine",
+          "past",
+          "perfective",
+          "indicative",
+          "short"
+        ]
+      ]
+    ],
+    0,
+    ""
+  ],
+  [
+    "простынёй",
+    "",
+    "non-lemma",
+    "",
+    0,
+    [
+      [
+        "простыня́",
+        [
+          "instrumental",
+          "singular"
+        ]
+      ]
+    ],
+    0,
+    ""
+  ],
+  [
     "снега",
     "сне́га",
     "non-lemma",

--- a/data/test/tidy/ru-en-forms-0.json
+++ b/data/test/tidy/ru-en-forms-0.json
@@ -2,6 +2,50 @@
   "_type": "map",
   "map": [
     [
+      "возни́кнуть",
+      {
+        "_type": "map",
+        "map": [
+          [
+            "возни́к",
+            {
+              "_type": "map",
+              "map": [
+                [
+                  "verb",
+                  [
+                    "short masculine singular past indicative perfective"
+                  ]
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    ],
+    [
+      "простыня́",
+      {
+        "_type": "map",
+        "map": [
+          [
+            "простынёй",
+            {
+              "_type": "map",
+              "map": [
+                [
+                  "noun",
+                  [
+                    "instrumental singular"
+                  ]
+                ]
+              ]
+            }
+          ]
+        ]
+      }
+    ],
+    [
       "снег",
       {
         "_type": "map",


### PR DESCRIPTION
I fixed some missing inflections for Russian.

Example:

`глубже` has these inflection glossary entries:

1. comparative degree of глубо́кий (glubókij)
2. comparative degree of глубоко́ (glubokó)

The ` (glubókij)` and ` (glubokó)` text was messing up the `lemmaMatch`.