### PR TITLE
[feat] Use multiple head infos

### DIFF
--- a/src/dict/main.rs
+++ b/src/dict/main.rs
@@ -1051,7 +1051,8 @@ fn process_entry(edition: Edition, source: Lang, entry: &WordEntry) -> LemmaInfo
         etymology_text: entry
             .etymology_texts()
             .map(|etymology_text| etymology_text.join("\n")),
-        head_info_text: get_head_info(&entry.head_templates).map(String::from),
+        head_info_text: get_head_info(&entry.head_templates)
+            .map(|head_info_text| head_info_text.join("\n")),
         link_wiktionary: link_wiktionary(edition, source, &entry.word),
         link_kaikki: link_kaikki(edition, source, &entry.word),
     }
@@ -1060,14 +1061,24 @@ fn process_entry(edition: Edition, source: Lang, entry: &WordEntry) -> LemmaInfo
 static PARENS_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\(.+?\)").unwrap());
 
 // rg: getheadinfo
-fn get_head_info(head_templates: &[HeadTemplate]) -> Option<&str> {
-    head_templates.iter().find_map(|head_template| {
-        if PARENS_RE.is_match(&head_template.expansion) {
-            Some(head_template.expansion.as_str())
-        } else {
-            None
-        }
-    })
+// For consistency, it's better if this function shares return type with .etymology_texts()
+fn get_head_info(head_templates: &[HeadTemplate]) -> Option<Vec<&str>> {
+    let result: Vec<_> = head_templates
+        .iter()
+        .filter_map(|head_template| {
+            if PARENS_RE.is_match(&head_template.expansion) {
+                Some(head_template.expansion.as_str())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if result.is_empty() {
+        None
+    } else {
+        Some(result)
+    }
 }
 
 fn get_gloss_tree(entry: &WordEntry) -> GlossTree {

--- a/tests/dict/de/en/temp-main/dict/term_bank_1.json
+++ b/tests/dict/de/en/temp-main/dict/term_bank_1.json
@@ -36,7 +36,7 @@
                         "data": {
                           "content": "Grammar-content"
                         },
-                        "content": "pflegen (weak, third-person singular present pflegt, past tense pflegte, past participle gepflegt, auxiliary haben)"
+                        "content": "pflegen (weak, third-person singular present pflegt, past tense pflegte, past participle gepflegt, auxiliary haben)\npflegen (class 4 strong, third-person singular present pflegt, past tense pflog, past participle gepflogen, past subjunctive pflöge, auxiliary haben)"
                       }
                     ]
                   },

--- a/tests/dict/de/en/temp-main/tidy/de-en-lemmas.json
+++ b/tests/dict/de/en/temp-main/tidy/de-en-lemmas.json
@@ -397,7 +397,7 @@
             }
           },
           "etymology_text": "From Middle High German phlëgen, from Old High German plëgan, from Proto-West Germanic *plehan.",
-          "head_info_text": "pflegen (weak, third-person singular present pflegt, past tense pflegte, past participle gepflegt, auxiliary haben)",
+          "head_info_text": "pflegen (weak, third-person singular present pflegt, past tense pflegte, past participle gepflegt, auxiliary haben)\npflegen (class 4 strong, third-person singular present pflegt, past tense pflog, past participle gepflogen, past subjunctive pflöge, auxiliary haben)",
           "wlink": "https://en.wiktionary.org/wiki/pflegen#German",
           "klink": "https://kaikki.org/dictionary/German/meaning/p/pf/pflegen.html"
         }

--- a/tests/dict/el/en/temp-main/dict/term_bank_1.json
+++ b/tests/dict/el/en/temp-main/dict/term_bank_1.json
@@ -36,7 +36,7 @@
                         "data": {
                           "content": "Grammar-content"
                         },
-                        "content": "έρχομαι • (érchomai)"
+                        "content": "έρχομαι • (érchomai)\nέρχομαι • (érchomai) deponent (past ήρθα/ήλθα)"
                       }
                     ]
                   },

--- a/tests/dict/el/en/temp-main/tidy/el-en-lemmas.json
+++ b/tests/dict/el/en/temp-main/tidy/el-en-lemmas.json
@@ -231,7 +231,7 @@
             }
           },
           "etymology_text": "From Ancient Greek ἔρχομαι (érkhomai, “I go”), from Proto-Indo-European *h₁ergʰ- (“to move, go”). The meaning shift and the perfective forms are from the suppletive aorist ἦλθον (êlthon, “I came”) (with regular shift λθ > ρθ). Compare also the Albanian form erdha (“I came”).",
-          "head_info_text": "έρχομαι • (érchomai)",
+          "head_info_text": "έρχομαι • (érchomai)\nέρχομαι • (érchomai) deponent (past ήρθα/ήλθα)",
           "wlink": "https://en.wiktionary.org/wiki/έρχομαι#Greek",
           "klink": "https://kaikki.org/dictionary/Greek/meaning/έ/έρ/έρχομαι.html"
         }

--- a/tests/dict/grc/en/temp-main/dict/term_bank_1.json
+++ b/tests/dict/grc/en/temp-main/dict/term_bank_1.json
@@ -36,7 +36,7 @@
                         "data": {
                           "content": "Grammar-content"
                         },
-                        "content": "ᾰ̓γρός • (ăgrós) m (genitive ᾰ̓γροῦ); second declension"
+                        "content": "ᾰ̓γρός • (ăgrós) m (genitive ᾰ̓γροῦ); second declension\n(Epic, Attic, Ionic, Doric, Koine)"
                       }
                     ]
                   },

--- a/tests/dict/grc/en/temp-main/tidy/grc-en-lemmas.json
+++ b/tests/dict/grc/en/temp-main/tidy/grc-en-lemmas.json
@@ -17,7 +17,7 @@
             }
           },
           "etymology_text": "From Proto-Hellenic *agrós, from Proto-Indo-European *h₂éǵros. Cognates include Mycenaean Greek 𐀀𐀒𐀫 (a-ko-ro), Latin ager, Sanskrit अज्र (ájra) and Old English æcer (English acre).",
-          "head_info_text": "ᾰ̓γρός • (ăgrós) m (genitive ᾰ̓γροῦ); second declension",
+          "head_info_text": "ᾰ̓γρός • (ăgrós) m (genitive ᾰ̓γροῦ); second declension\n(Epic, Attic, Ionic, Doric, Koine)",
           "wlink": "https://en.wiktionary.org/wiki/ἀγρός#Ancient Greek",
           "klink": "https://kaikki.org/dictionary/Ancient%20Greek/meaning/ἀ/ἀγ/ἀγρός.html"
         }

--- a/tests/dict/ja/en/temp-main/dict/term_bank_1.json
+++ b/tests/dict/ja/en/temp-main/dict/term_bank_1.json
@@ -1843,7 +1843,7 @@
                         "data": {
                           "content": "Grammar-content"
                         },
-                        "content": "五(ご)色(しき) • (goshiki) ^(←ごしき (gosiki)?)"
+                        "content": "五(ご)色(しき) • (goshiki) ^(←ごしき (gosiki)?)\n五(ご)色(しょく) • (goshoku) ^(←ごしよく (gosyoku)?)"
                       }
                     ]
                   }

--- a/tests/dict/ja/en/temp-main/tidy/ja-en-lemmas.json
+++ b/tests/dict/ja/en/temp-main/tidy/ja-en-lemmas.json
@@ -436,7 +436,7 @@
             "five colors (usu. red (赤), blue (青), yellow (黄), white (白) and black (黒))": {},
             "synonym of 瓜 (uri, “melon, gourd”)": {}
           },
-          "head_info_text": "五(ご)色(しき) • (goshiki) ^(←ごしき (gosiki)?)",
+          "head_info_text": "五(ご)色(しき) • (goshiki) ^(←ごしき (gosiki)?)\n五(ご)色(しょく) • (goshoku) ^(←ごしよく (gosyoku)?)",
           "wlink": "https://en.wiktionary.org/wiki/五色#Japanese",
           "klink": "https://kaikki.org/dictionary/Japanese/meaning/五/五色/五色.html"
         }

--- a/tests/dict/la/en/temp-main/dict/term_bank_1.json
+++ b/tests/dict/la/en/temp-main/dict/term_bank_1.json
@@ -2322,7 +2322,7 @@
                         "data": {
                           "content": "Grammar-content"
                         },
-                        "content": "in (+ ablative)"
+                        "content": "in (+ ablative)\nin (+ accusative)"
                       }
                     ]
                   },

--- a/tests/dict/la/en/temp-main/tidy/la-en-lemmas.json
+++ b/tests/dict/la/en/temp-main/tidy/la-en-lemmas.json
@@ -715,7 +715,7 @@
             }
           },
           "etymology_text": "From earlier en, from Proto-Italic *en, from Proto-Indo-European *h₁én (“in”). Cognates include English in, Ancient Greek ἐν (en).\nThe ablative is from the locative, and the accusative is from the directional.",
-          "head_info_text": "in (+ ablative)",
+          "head_info_text": "in (+ ablative)\nin (+ accusative)",
           "wlink": "https://en.wiktionary.org/wiki/in#Latin",
           "klink": "https://kaikki.org/dictionary/Latin/meaning/i/in/in.html"
         }


### PR DESCRIPTION
Addresses this part of #190 

> Second, although it’s not very common, some words have multiple head-infos. Unfortunately, the current dictionaries seem to display only one of them (e.g., 'E-mail' and 'Joghurt' in de-en).

Because it's quite rare, we don't store them as a Vec internally (to avoid alloc for just one string most of the time, even though I think it wouldn't matter much), and we join by newline. It imitates what was being done with `etymology_text`(s) and shows not structured, raw text.

---

<img width="500" height="350" alt="image" src="https://github.com/user-attachments/assets/a2a7cdba-698d-4d61-9045-e5e431a53174" />
