### PR TITLE
[docs] Document why css fallbacks are a bad idea

### DIFF
--- a/docs/css.md
+++ b/docs/css.md
@@ -1,6 +1,7 @@
 ## Prelude
 
-- The css used by all dictionaries can be found [here](https://raw.githubusercontent.com/yomidevs/wiktionary-to-yomitan/master/assets/styles.css).
+- The css used by all `wty` dictionaries can be found [here](https://raw.githubusercontent.com/yomidevs/wiktionary-to-yomitan/master/assets/styles.css).
+- The css found on Yomitan side can be found at this [folder](https://github.com/yomidevs/yomitan/tree/master/ext/css), with secret css variables like `--text-color` at [material.css](https://github.com/yomidevs/yomitan/blob/master/ext/css/material.css). Note that these variables will not work in Anki because Yomitan does not support their extraction, and adding fallbacks in `styles.css` may interfere with the user theme.
 - Yomitan documentation contains [themes](https://yomitan.wiki/tools-resources/?h=css#yomitan-colored-css) and how to set them up.
 - The sunset Yomichan has a still mostly valid [guide](https://learnjapanese.moe/yomicss/) on how to customize css.
 


### PR DESCRIPTION
Closes #196

Replaces every `var(--X)` with `var(--X, hardcode_value)`. This should carry the colours to anki.

Uses the defaults for the light theme. I added where to find them too in the docs.

---

Old/New

<img width="1558" height="1155" alt="old" src="https://github.com/user-attachments/assets/444aa756-c345-4114-b6d3-8d312efcb2d2" />

<img width="1558" height="1155" alt="new2" src="https://github.com/user-attachments/assets/513032a1-29c9-4edc-b8f6-b6a9e3e4da24" />


